### PR TITLE
Fix deps, and change up exposed api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,5 @@ docs/_build/
 
 # Pyenv
 .python-version
+
+.pdm-python

--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ On more exotic linux versions, or custom environments such as HPCs, the precompi
 
 First, ensure rust is installed on your system. You can follow the simple instructions from [rustup](https://rustup.rs/) to install directly, or on an HPC, load up rust using its software version control (e.g. for `lmod`: `module load rust`). Then just pip-install as normal, and `rsbids` should automatically be compiled (note that it may take several minutes).
 
+
+## Benchmarks
+
+Benchmarks are calculated on the openly available [_HBN EO/EC task_ dataset](https://openneuro.org/datasets/ds004186/versions/2.0.0), consisting of 177,065 files, including metadata. `rsbids` is compared to [`pybids`](https://github.com/bids-standard/pybids), [`ancpbids-bids`](https://github.com/ANCPLabOldenburg/ancp-bids), and [`bids2table`](https://github.com/cmi-dair/bids2table). The code for running the benchmarks and generating the figure can be found at the [rsbids-benchmark](https://github.com/pvandyken/rsbids-benchmark.git) repository. More information on the method and tasks can be found there.
+
+![Benchmarks for rsbids](https://github.com/pvandyken/rsbids-benchmark/blob/07b1fdeee5be4ceda03737f793bb7e38042f03d5/assets/benchmarks.png)
+
 ## Notable differences from pybids
 
 Along with the substantial speed boost, `rsbids` optimizes many aspects of the `pybids` api:

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Thus, `rsbids` allows multiple raw roots:
 
 ```python
 # rsbids
-layout = rsbids.layout(["root1", "root2"])
+layout = rsbids.BidsLayout(["root1", "root2"])
 ```
 
 These roots can be then queried using roots:
@@ -127,7 +127,7 @@ New to `rsbids`, derivatives can be labelled:
 
 ```python
 #rsbids
-layout = rsbids.layout(
+layout = rsbids.BidsLayout(
     "dataset",
     derivatives={
         "proc1": "dataset/derivatives/proc1-v0.10.1",
@@ -156,7 +156,7 @@ layout.roots
 If the dataset has a single raw root (with any number of derivatives), the `.root` attribute can be used to retrieve that root:
 
 ```python
-layout = rsbids.layout(
+layout = rsbids.BidsLayout(
     "dataset",
     derivatives={
         "proc1": "dataset/derivatives/proc1-v0.10.1",
@@ -169,7 +169,7 @@ layout.root == "dataset"
 If there is no raw root, but exactly one derivative root, `.root` will retrieve the derivative
 
 ```python
-layout = rsbids.layout(
+layout = rsbids.BidsLayout(
     "dataset",
     derivatives={
         "proc1": "dataset/derivatives/proc1-v0.10.1",
@@ -181,7 +181,7 @@ layout.filter(scope="proc1").root == "dataset/derivatives/proc1-v0.10.1"
 All other calls to `.root` will error:
 
 ```python
-layout = rsbids.layout(
+layout = rsbids.BidsLayout(
     "dataset",
     derivatives={
         "proc1": "dataset/derivatives/proc1-v0.10.1",
@@ -193,7 +193,7 @@ layout.derivatives.root # !!! Error: multiple roots
 The `.description` attribute works according to equivalent logic:
 
 ```python
-layout = rsbids.layout(
+layout = rsbids.BidsLayout(
     "dataset",
     derivatives={
         "proc1": "dataset/derivatives/proc1-v0.10.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "typing-extensions>=3.7.4.1",
+    "typing-extensions>=4.6.0",
 ]
 
 

--- a/rsbids/__init__.py
+++ b/rsbids/__init__.py
@@ -1,3 +1,5 @@
-from rsbids.entry import parse, layout
+from rsbids.entry import parse
+from rsbids._lib import BidsLayout
+from rsbids.bidspath import BidsPath
 
-__all__ = ["layout", "parse"]
+__all__ = ["BidsLayout", "parse", "BidsPath"]

--- a/rsbids/__init__.pyi
+++ b/rsbids/__init__.pyi
@@ -1,3 +1,5 @@
-from .entry import parse, layout
+from rsbids.entry import parse
+from rsbids._lib import BidsLayout
+from rsbids.bidspath import BidsPath
 
-__all__ = ["layout", "parse"]
+__all__ = ["BidsLayout", "parse", "BidsPath"]

--- a/rsbids/entry.py
+++ b/rsbids/entry.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING, Iterable, overload, Mapping
+from typing import TYPE_CHECKING, Iterable, overload
 
 from rsbids.bidspath import BidsPath
-from rsbids._lib import BidsLayout
 
 
 if TYPE_CHECKING:
-    from rsbids._lib import StrPath, DerivPathList
+    from rsbids._lib import StrPath
 
 
 @overload
@@ -27,20 +26,3 @@ def parse(path: StrPath | Iterable[StrPath]):
         for p in path:  # type: ignore
             result.append(BidsPath(p))  # type: ignore
         return result
-
-
-def layout(
-    roots: None | StrPath | Iterable[StrPath] = ...,
-    derivatives: None | bool | DerivPathList | Mapping[str, DerivPathList] = ...,
-    *,
-    validate: bool = False,
-    cache: StrPath | None = None,
-    reset_cache: bool = False,
-):
-    return BidsLayout(
-        roots=roots,
-        derivatives=derivatives,
-        validate=validate,
-        cache=cache,
-        reset_cache=reset_cache,
-    )


### PR DESCRIPTION
Remove `rsbids.layout` as it doesn't add anything new. `rsbids.BidsLayout` and `rsbids.BidsPath` are now exposed. `rsbids.parse` will stay around for now because it can parse an iterable of paths in addition to just one (so it's not a blind wrapper around `BidsPath`), and it also corresponds nicely with `rsbids.BidsLayout.parse`.

Add benchmark info to README.

I set the min for `typing_extensions` way too low, this should hopefully fix it