### PR TITLE
Fix bug in UserPathParents

### DIFF
--- a/rsbids/bidspath.py
+++ b/rsbids/bidspath.py
@@ -59,14 +59,12 @@ class BidsPath(UserPath):
         self, paths: Iterable[Self], exclude: Container[str] | None = None
     ):
         exclude = set() if exclude is None else exclude
-        print(self)
         for path in paths:
             entities = {e: v for e, v in path.entities.items() if e not in exclude}
             theirs = set(entities.items())
             ours = set(self.entities.items())
             # They have no keys we don't have, and at least one of our keys
             if not theirs - ours and theirs & ours:
-                print(path)
                 yield path
 
     def _parse(self, path: Path):

--- a/rsbids/userpath.py
+++ b/rsbids/userpath.py
@@ -1,19 +1,69 @@
+"""Backport of py312 features
+
+py312 introduces `Path.with_segments`, allowing `Path` to be flexibly, stably
+subclassed, even across future feature additions and API changes. This module backports
+that method as far as py38. Certain other features, such as indexing `Path.parents` with
+slices and negative numbers, are also backported
+"""
 from __future__ import annotations
 from pathlib import Path, PurePath
 from pathlib import _PathParents  # type: ignore
 import sys
-from typing import TYPE_CHECKING, Any, Generator, Sequence
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Generator,
+    Sequence,
+    SupportsIndex,
+    cast,
+    overload,
+)
 from typing_extensions import Self
 
 if TYPE_CHECKING:
     from _typeshed import StrPath
 
+
 class _UserPathParents(_PathParents):  # type: ignore
-    def __getitem__(self, idx: int) -> Path:
-        elem = super().__getitem__(idx)  # type: ignore
-        if isinstance(elem, tuple):
-            return tuple(self.with_segments(p) for p in elem)  # type: ignore
-        return self.with_segments(elem)  # type: ignore
+    """This object provides sequence-like access to the logical ancestors
+    of a path.  Don't try to construct it yourself."""
+
+    def __init__(self, path: UserPath):
+        super().__init__(Path(path))  # type: ignore
+        self.path = path
+
+    @overload
+    def __getitem__(self, idx: SupportsIndex) -> Path:
+        ...
+
+    @overload
+    def __getitem__(self, idx: slice) -> tuple[Path, ...]:
+        ...
+
+    if sys.version_info < (3, 10):
+
+        def __getitem__(self, idx: SupportsIndex | slice) -> Path | tuple[Path, ...]:
+            if isinstance(idx, slice):
+                return tuple(self._get(i) for i in range(len(self))[idx])
+            idx = int(idx)
+            if idx < 0:
+                return self._get(len(self) + idx)
+            return self._get(idx)
+
+    else:
+
+        def __getitem__(self, idx: SupportsIndex | slice) -> Path | tuple[Path, ...]:
+            elem = cast(
+                "tuple[Path, ...] | Path", super().__getitem__(idx)  # type: ignore
+            )
+            if isinstance(elem, tuple):
+                return tuple(self.path.with_segments(p) for p in elem)
+            return self.path.with_segments(elem)
+
+    def _get(self, idx: SupportsIndex) -> Path:
+        elem = cast("Path", super().__getitem__(idx))  # type: ignore
+        return self.path.with_segments(elem)
+
 
 class UserPathImpl(type(Path())):
     entities: dict[str, str]
@@ -48,6 +98,7 @@ class UserPathImpl(type(Path())):
         return self.with_segments(Path(self).with_name(name))
 
     if sys.version_info >= (3, 9):
+
         def with_stem(self, stem: str) -> Self:
             return self.with_segments(Path(self).with_stem(stem))
 


### PR DESCRIPTION
Some refactoring I did previously was never tested, and didn't work at all. Should be in order now

Downstream, this prevented `BidsPath.metadata` from working