### PR TITLE
Add codespell support (config, workflow to detect/not fix) and make it fix few typos

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,25 @@
+# Codespell configuration is within pyproject.toml
+---
+name: Codespell
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Annotate locations with typos
+        uses: codespell-project/codespell-problem-matcher@v1
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 `rsbids` is a rust implementation of [`pybids`](https://github.com/bids-standard/pybids), currently under active development. It offers vastly improved runtimes compared to other bids indexers (benchmarks to come), a streamlined core api, and a pybids compatibility api.
 
-**`rsbids` is currently in alpha**. Most of the core pybids features are implemented, however, there is little to no automated testing or documentation. It has only rudimentary validation and no configurability. Pybids compatibility has been implemented for much of `pybids.layout.layout`, `pybids.layout.indexers`, and `pybids.layout.models`. Not all features are available, however. Whenever possible, a `CompatibilityError` or warning will be raised when these features are encountered. Finally, api stability is not guarenteed for any aspect of the api.
+**`rsbids` is currently in alpha**. Most of the core pybids features are implemented, however, there is little to no automated testing or documentation. It has only rudimentary validation and no configurability. Pybids compatibility has been implemented for much of `pybids.layout.layout`, `pybids.layout.indexers`, and `pybids.layout.models`. Not all features are available, however. Whenever possible, a `CompatibilityError` or warning will be raised when these features are encountered. Finally, api stability is not guaranteed for any aspect of the api.
 
 The alpha period is an opportunity to test and experiment. Community engagement and feedback is highly valued, and will have an impact on future development. In the immediate future, work will focus on testing, stability, and basic configuration/validation. However, any feature ideas and feedback on the api are welcome. (Note that there's a number of issues I'm already aware of, so be sure to read this document before leaving bug reports).
 
@@ -32,7 +32,7 @@ Benchmarks are calculated on the openly available [_HBN EO/EC task_ dataset](htt
 
 ## Pybids Compatibility
 
-A compability api can be found under `rsbids.pybids`. So in general, you can:
+A compatibility api can be found under `rsbids.pybids`. So in general, you can:
 
 ```py
 # replace
@@ -113,9 +113,9 @@ layout.get(subject="001", session="02", suffix="dwi", extension=".nii.gz")[0]
 layout.get(subject="001", session="02", suffix="dwi", extension=".nii.gz").one
 ```
 
-### Seperate `.get()` and `.filter()` methods
+### Separate `.get()` and `.filter()` methods
 
-`pybids` uses the `.get()` method as an omnibus query method. While convenient, it makes the method brittle because certain arguments are interpreted with special meaning (e.g. `scope`, `target`). This makes it challenging to add additional query methods (e.g. searching specificially by `pipeline` or file `root`).
+`pybids` uses the `.get()` method as an omnibus query method. While convenient, it makes the method brittle because certain arguments are interpreted with special meaning (e.g. `scope`, `target`). This makes it challenging to add additional query methods (e.g. searching specifically by `pipeline` or file `root`).
 
 With the split, arguments to `.get()` will always be interpreted as entity names (e.g. `subject`, `session`, `run`, etc) or metadata keys (e.g. `EchoTime`, etc). All other special search modes are handled by `.filter()`. Because each query returns a new layout, it's perfectly possible to chain these calls together, making an extremely flexible query interface.
 
@@ -272,7 +272,7 @@ layout.index_metadata().get(EchoTime="...")
 
 ### dtypes
 
-`pybids` associates each entity with a specific datatype. Most entities are strings, but some, such as `run`, are explicitely stored as integers.
+`pybids` associates each entity with a specific datatype. Most entities are strings, but some, such as `run`, are explicitly stored as integers.
 
 `rsbids` stores all entities as strings. This simplifies the layout internals and ensures entities are saved nondestructively. For those used to querying runs with integers, however, fear not! `rsbids.get()` accepts integer queries for ALL entities:
 
@@ -295,7 +295,7 @@ If multiple valid matches are found, an error will be thrown.
 
 `rsbids` has two variants of its parsing algorithm. One looks for `entity-value` pairs specifically defined by the bids spec (similar to how pybids and all other bids indexers currently work). Invalid entities (`..._foobar-val_...`) are ignored. This mode is enabled by `rsbids.layout(..., validate=True)`, and gives a validation experience _somewhat_ similar to `pybids.BIDSLayout(..., validate=False, is_derivative=True)` (note that this will change in the future to match the `pybids` defaults).
 
-The other parser is completely generic: it parses any path looking for `entity-value` combinations seperated by underscores (`_`). So long as the path structure looks _roughly_ bids-like, `rsbids` should correctly parse it, including missing extensions/suffixes, custom entities, any arbitrary value (so long as it has no `_`), custom datatypes, malformed directory structures, etc.
+The other parser is completely generic: it parses any path looking for `entity-value` combinations separated by underscores (`_`). So long as the path structure looks _roughly_ bids-like, `rsbids` should correctly parse it, including missing extensions/suffixes, custom entities, any arbitrary value (so long as it has no `_`), custom datatypes, malformed directory structures, etc.
 
 The flexible algorithm currently has **no** validation, so any path will be parsed into _something_ according to the algorithm. In the future, `rsbids` will allow for more fine-grained validation.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,3 +31,10 @@ dev = [
     "hypothesis>=6.91.0",
     "more-itertools>=8",
 ]
+
+[tool.codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = '.git*,*.lock'
+check-hidden = true
+# ignore-regex = ''
+# ignore-words-list = ''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,4 +37,4 @@ dev = [
 skip = '.git*,*.lock'
 check-hidden = true
 # ignore-regex = ''
-# ignore-words-list = ''
+ignore-words-list = 'crate,ser'

--- a/rsbids/bidspath.py
+++ b/rsbids/bidspath.py
@@ -44,7 +44,7 @@ class BidsPath(UserPath):
             jsons = [self._parse(p) for p in parent.iterdir() if p.suffix == ".json"]
             jsons = list(self._subset_paths(jsons, exclude="extension"))
 
-            # For propery bids validity, there should only be one file at this point,
+            # For proper bids validity, there should only be one file at this point,
             # but don't worry about that for now
             for path in jsons:
                 result.update(path.read_json())

--- a/src/dataset_description.rs
+++ b/src/dataset_description.rs
@@ -146,7 +146,7 @@ pub struct SourceDatasetBin {
     pub version: Option<String>,
 }
 
-/// DefaultOnError breaks bincode, so keep a seperate, simplified struct for encoding to bin
+/// DefaultOnError breaks bincode, so keep a separate, simplified struct for encoding to bin
 #[derive(Debug, Default, Serialize, Deserialize, Clone)]
 pub struct DatasetDescriptionBin {
     pub name: Option<String>,

--- a/src/layout/cache.rs
+++ b/src/layout/cache.rs
@@ -14,9 +14,9 @@ pub struct LayoutCache;
 
 impl LayoutCache {
     fn write(path: PathBuf, data: Vec<u8>) -> io::Result<()> {
-        let decleration = Vec::from(DECLARATION);
+        let declaration = Vec::from(DECLARATION);
         let mut file = fs::File::create(path)?;
-        file.write_all(&decleration)?;
+        file.write_all(&declaration)?;
         file.write_all(&data)?;
         Ok(())
     }


### PR DESCRIPTION
More about codespell: https://github.com/codespell-project/codespell .

I personally introduced it to dozens if not hundreds of projects already and so far only positive feedback.

CI workflow has 'permissions' set only to 'read' so also should be safe.